### PR TITLE
Feat: totally hide menubar

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,10 +57,17 @@ const createWindow = () => {
       enableRemoteModule: true
     },
     autoHideMenuBar: true,
-    useContentSize: true
+    useContentSize: true,
+    fullscreenable: false,
   })
   
   mainWindow.loadFile("index.html")
+
+  // Feat: totally hide menubar
+  // Prevent user accidently triggers showing menubar by pressing 'alt'
+  // also prevent user turns up devtool by ketboard shortcut
+  let menu = new Menu();
+  Menu.setApplicationMenu(menu);
 
   // Minimizing to and restoring from tray
   mainWindow.on("minimize", () => {


### PR DESCRIPTION
I found out that when I alt tab to other program, the menubar would show up.
After that I confirmed that pressing 'alt' key will show the menubar.
And with the "hidden" menubar existing, users could easily turn on devtools by pressing ctrl + shift + i shortcut. So I replace the default menubar to totally no menubar, this also prevent turning on devtools with key shortcuts.