### PR TITLE
Migrate all PubSub usage to EventSub

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@twurple/auth": "^7.0.7",
     "@twurple/chat": "^7.0.7",
     "@twurple/eventsub-ws": "^7.0.7",
-    "@twurple/pubsub": "^7.0.7",
     "electron-squirrel-startup": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PubSub has been deprecated and will be removed completely on 14 Apr 2024, and Twitch has been turning off PubSub on their side every now and then before that date to bring this to people's attention (see https://discuss.dev.twitch.com/t/legacy-pubsub-deprecation-and-shutdown-timeline/58043 for more details).

Unfortunately I've only been able to test the channel point redemptions, so I'm not sure if the subs and bits still work, I've only modified them as best I can following the Twurple EventSub API documentation.